### PR TITLE
Draft: Fix memory leaks

### DIFF
--- a/src/taco_tensor_t.cpp
+++ b/src/taco_tensor_t.cpp
@@ -67,6 +67,7 @@ taco_tensor_t* init_taco_tensor_t(int32_t order, int32_t csize,
 }
 
 void deinit_taco_tensor_t(taco_tensor_t* t) {
+  free_mem(t->fill_value);
   for (int i = 0; i < t->order; i++) {
     free_mem(t->indices[i]);
   }


### PR DESCRIPTION
- Fixes a small memory leak in taco_tensor
- Applies a commit from an umerged PR on the original taco repository, which fixes a larger leak. However, a invalid free() is reported by valgrind, hence this solution might have its own problems

For a simple toy contraction example, this reduces the amount of definitely lost bytes from 292 to 48.