### PR TITLE
Memory leak fix

### DIFF
--- a/src/taco_tensor_t.cpp
+++ b/src/taco_tensor_t.cpp
@@ -67,6 +67,7 @@ taco_tensor_t* init_taco_tensor_t(int32_t order, int32_t csize,
 }
 
 void deinit_taco_tensor_t(taco_tensor_t* t) {
+  free_mem(t->fill_value);
   for (int i = 0; i < t->order; i++) {
     free_mem(t->indices[i]);
   }


### PR DESCRIPTION
Reduces the amount of definitively lost bytes from 292 to 48.

However, valgrind reports an invalid free() that was introduced by the fix. This has to be investigated further.